### PR TITLE
Fixed test to detect the correct "Credit or debit card" field

### DIFF
--- a/tests/subscription/dropin-card.spec.js
+++ b/tests/subscription/dropin-card.spec.js
@@ -20,7 +20,6 @@ test('Dropin Card', async ({ page }) => {
     const frame = page.frameLocator('iframe');
     
     // Select "Credit or debit card"
-    // Select "Credit or debit card"
     await page.click('[aria-label="Credit or debit card"]');
     await expect(page.locator('[aria-label="Credit or debit card"]')).toHaveAttribute('aria-expanded', 'true');
 

--- a/tests/subscription/dropin-card.spec.js
+++ b/tests/subscription/dropin-card.spec.js
@@ -14,7 +14,7 @@ test('Dropin Card', async ({ page }) => {
 
     // Click "Continue to confirm subscription"
     await page.click('text="Continue to confirm subscription"');
-    await expect(page.locator('text="Card number"')).toBeVisible();
+    await expect(page.locator('text="Credit or debit card"')).toBeVisible();
 
     // Locate iframe
     const frame = page.frameLocator('iframe');


### PR DESCRIPTION
Description:

Depending what payment methods you have enabled in the Customer Area, we cannot always assume the "Card number" to be the first visible item for Drop-in. 

Instead, we detect the "Credit or debit card"-field to be visible before select the right iframe --> which fixes the faulty test

