### PR TITLE
#2 Add E2E Card payment for checkout

### DIFF
--- a/tests/checkout/dropin-card.spec.js
+++ b/tests/checkout/dropin-card.spec.js
@@ -1,19 +1,23 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
-test('Card', async ({ page }) => {
+test('Dropin Card', async ({ page }) => {
     await page.goto('/');
 
     await expect(page).toHaveTitle(/Checkout Demo/);
     await expect(page.locator('text="Select a demo"')).toBeVisible();
 
-    // Select "Card"
-    await page.getByRole('link', { name: 'Card' }).click();
+    // Select "Drop-in"
+    await page.getByRole('link', { name: 'Drop-in' }).click();
     await expect(page.locator('text="Cart"')).toBeVisible();
 
     // Click "Continue to checkout"
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
-    await expect(page.locator('text="Card number"')).toBeVisible();
+    await expect(page.locator('text="Credit or debit card"')).toBeVisible();
+    
+    // Select "Credit or debit card"
+    await page.getByRole('button', { name: 'Credit or debit card' }).click();
+    await expect(page.locator('[aria-label="Credit or debit card"]')).toHaveAttribute('aria-expanded', 'true');
     
     // Find iframe and fill "Card number" field
     const cardNumberFrame = page.frameLocator('internal:attr=[title="Iframe for secured card number"i]');
@@ -24,7 +28,7 @@ test('Card', async ({ page }) => {
     await expiryDateFrame.getByPlaceholder('MM/YY').fill('03/30');
 
     // Find iframe and fill "CVC / CVV" field
-    const cvcFrame = page.frameLocator('internal:attr=[title="Iframe for secured card security code"i]');
+    const cvcFrame = page.frameLocator('internal:role=region[name="Credit or debit card"i] >> internal:attr=[title="Iframe for secured card security code"i]');
     await cvcFrame.getByPlaceholder('3 digits').fill('737');
    
     // Find and fill "Name on card" field - Note: this field is not contained within an iframe

--- a/tests/checkout/dropin-sepa.spec.js
+++ b/tests/checkout/dropin-sepa.spec.js
@@ -1,7 +1,6 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
-// SEPA payment
 test('Dropin SEPA', async ({ page }) => {
     await page.goto('/');
 
@@ -9,11 +8,12 @@ test('Dropin SEPA', async ({ page }) => {
     await expect(page.locator('text="Select a demo"')).toBeVisible();
 
     // Select "Drop-in"
-    await page.locator('text="Drop-in"').click();
+    await page.getByRole('link', { name: 'Drop-in' }).click();
     await expect(page.locator('text="Cart"')).toBeVisible();
 
     // Click "Continue to checkout"
-    await page.click('text="Continue to checkout"');
+    
+    await page.getByRole('link', { name: 'Continue to checkout' }).click();
     await expect(page.locator('text="SEPA Direct Debit"')).toBeVisible();
 
     // Select "SEPA"
@@ -21,7 +21,7 @@ test('Dropin SEPA', async ({ page }) => {
     await page.fill('input[name="ownerName"]', "A. Klaassen");
     await page.fill('input[name="ibanNumber"]', "NL13TEST0123456789");
 
-    // Click "Pay"
+    // Click "Pay" button
     const payButton = page.locator('.adyen-checkout__button.adyen-checkout__button--pay >> visible=true');
     await expect(payButton).toBeVisible();
     await payButton.click();

--- a/tests/checkout/ideal.spec.js
+++ b/tests/checkout/ideal.spec.js
@@ -7,26 +7,27 @@ test('iDEAL', async ({ page }) => {
     await expect(page).toHaveTitle(/Checkout Demo/);
     await expect(page.locator('text="Select a demo"')).toBeVisible();
 
-    // select iDEAL
-    await page.locator('text="iDEAL"').click();
+    // Select "iDEAL"
+    await page.getByRole('link', { name: 'iDEAL' }).click();
     await expect(page.locator('text="Cart"')).toBeVisible();
 
-    // click "Continue to checkout"
-    await page.click('text="Continue to checkout"');
+    // Click "Continue to checkout"
+    await page.getByRole('link', { name: 'Continue to checkout' }).click();
     await expect(page.locator('text="Select your bank"')).toBeVisible();
 
-    // Select bank
+    // Click "Select your bank"
     await page.click('text="Select your bank"');
-    // Choose Test Issuer
+
+    // Choose "Test Issuer"
     const element = page.locator('input[aria-autocomplete="list"]');
     await element.type('Test Issuer');
     await element.press('Enter');
 
-    // click "Continue to Test Issuer"
+    // Click "Continue to Test Issuer"
     await page.click('text="Continue to Test Issuer"');
     await expect(page.locator('text="iDEAL Issuer Simulation"')).toBeVisible();
 
-    // click "Continue"
+    // Click "Continue"
     await page.click('text="Continue"');
     await expect(page.locator('text="Return Home"')).toBeVisible();
 });

--- a/tests/checkout/klarna-paynow.spec.js
+++ b/tests/checkout/klarna-paynow.spec.js
@@ -8,14 +8,14 @@ test('Klarna Pay Now', async ({ page }) => {
     await expect(page.locator('text="Select a demo"')).toBeVisible();
 
     // Select "Klarna Pay Now"
-    await page.locator('text="Klarna - Pay now"').click();
+    await page.getByRole('link', { name: 'Klarna - Pay now' }).click();
     await expect(page.locator('text="Cart"')).toBeVisible();
 
     // Click "Continue to checkout"
-    await page.click('text="Continue to checkout"');
+    await page.getByRole('link', { name: 'Continue to checkout' }).click();
     await expect(page.locator('text="Continue to Pay now with Klarna."')).toBeVisible();
 
-    // Click "Continue to Klarna"
+    // Click "Continue to Klarna"    
     await page.locator('text="Continue to Pay now with Klarna."').click();
     await expect(page).toHaveTitle("Je bestelling afronden");
 });

--- a/tests/subscription/card.spec.js
+++ b/tests/subscription/card.spec.js
@@ -1,14 +1,13 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
-
 test('Card', async ({ page }) => {
     await page.goto('/');
 
     await expect(page).toHaveTitle("Adyen Subscription Shopper View");
     await expect(page.locator('text="SHOPPER VIEW"')).toBeVisible();
 
-    // Select Card
+    // Select "Card"
     await page.getByRole('link', { name: 'Card' }).click();
     await expect(page.locator('text="SUBSCRIPTION DETAILS"')).toBeVisible();
 

--- a/tests/subscription/dropin-card.spec.js
+++ b/tests/subscription/dropin-card.spec.js
@@ -1,7 +1,6 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
-// SEPA payment
 test('Dropin Card', async ({ page }) => {
     await page.goto('/');
 


### PR DESCRIPTION
**Description:**
- Added E2E for card payments for checkout.
- Use `await page.getByRole('link', { name: 'Card' }).click();` instead of  `await page.locator('text="Card"').click();` for more robust link testing. If the HTML-page somehow happens to have another text "Card" then it won't target that specific element.
- CamelCased the `// Comments`style for code consistency
