### PR TITLE
Add gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+tasks:
+  - name: Gitpod Task
+    init: |
+      npm install
+      npm i -D @playwright/test
+      npx playwright install-deps
+      npx playwright install
+    command: | 
+      echo "Run the test suite using the following command: URL=https://8080-adyenexampl-adyendotnet-1xxxxxxxxxx.ws-eu88.gitpod.io npx playwright test checkout"
+      echo "The URL refers to the baseUrl of the application you want to test."

--- a/README.md
+++ b/README.md
@@ -67,7 +67,27 @@ Note: the localhost application will resolve to `http://docker:8080` from inside
 
 
 ```
-  # run on Mac (i.e. --platform linux/arm64/v8)
+  # Run on Mac (i.e. --platform linux/arm64/v8)
   # NOTE!! Set <host IP address> before executing docker run
   docker run -t -i --rm --name adyen-testing-suite -e URL=http://docker:8080 -e PLAYWRIGHT_FOLDERNAME=checkout --add-host=docker:<host IP address> --platform linux/arm64/v8 ghcr.io/adyen-examples/adyen-testing-suite:main
+```
+
+
+## Run in Gitpod
+
+Run the testing-suite in Gitpod by pointing the `baseUrl` of our test configuration to the public URL of the application.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/adyen-examples/adyen-testing-suite)
+
+There are two ways to run the tests:
+
+1. Run the following command with the URL set to the public URL of the application.
+```
+URL=https://8080-adyenexampl-adyendotnet-1xxxxxxxxxx.ws-eu88.gitpod.io npx playwright test checkout
+```
+
+2. Modify the `playwright.config.js` file and replace `http://localhost:8080` with the public URL of the application. After modifying the URL, (re)run the command `npx playwright install`, followed by `npx playwright test checkout`.
+```
+# See 'http://localhost:8080' in playwright.config.js
+baseURL: process.env.URL || 'http://localhost:8080'
 ```

--- a/tests/checkout/klarna-paynow.spec.js
+++ b/tests/checkout/klarna-paynow.spec.js
@@ -17,5 +17,5 @@ test('Klarna Pay Now', async ({ page }) => {
 
     // Click "Continue to Klarna"    
     await page.locator('text="Continue to Pay now with Klarna."').click();
-    await expect(page).toHaveTitle("Je bestelling afronden");
+    await expect(page).toHaveTitle("Complete your purchase");
 });


### PR DESCRIPTION
**Context**
I spin up two gitpod instances (public URL)
Step 1) Testing-suite
Step 2) One of our integration-examples

I can now run the testing-suite against the 2nd instance of the gitpod workspace with the integration-example.

Step 3) Profit.