### PR TITLE
Card test: match exact

### DIFF
--- a/tests/checkout/card.spec.js
+++ b/tests/checkout/card.spec.js
@@ -8,7 +8,7 @@ test('Card', async ({ page }) => {
     await expect(page.locator('text="Select a demo"')).toBeVisible();
 
     // Select "Card"
-    await page.getByRole('link', { name: 'Card' }).click();
+    await page.getByRole('link', { name: 'Card', exact: true }).click();
     await expect(page.locator('text="Cart"')).toBeVisible();
 
     // Click "Continue to checkout"


### PR DESCRIPTION
Use match exact when using `getByRole` to make sure to get only one element matching 'Card' (ie in case there are other payment methods like PaySafe Card, etc...)