### PR TITLE
Fix for Web Dropin v5.33.0 - Select element by using getByRole('radio') instead of 'button'

### DIFF
--- a/tests/checkout/dropin-card.spec.js
+++ b/tests/checkout/dropin-card.spec.js
@@ -15,9 +15,8 @@ test('Dropin Card', async ({ page }) => {
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
     await expect(page.locator('text="Credit or debit card"')).toBeVisible();
     
-    // Select "Credit or debit card"
-    await page.getByRole('button', { name: 'Credit or debit card' }).click();
-    await expect(page.locator('[aria-label="Credit or debit card"]')).toHaveAttribute('aria-expanded', 'true');
+    // Click "Credit or debit card"
+    await page.getByRole('radio', { name: 'Credit or debit card' }).click();
     
     // Find iframe and fill "Card number" field
     const cardNumberFrame = page.frameLocator('internal:attr=[title="Iframe for secured card number"i]');

--- a/tests/subscription/dropin-card.spec.js
+++ b/tests/subscription/dropin-card.spec.js
@@ -15,9 +15,8 @@ test('Dropin Card', async ({ page }) => {
     await page.getByRole('link', { name: 'Continue to confirm subscription' }).click();
     await expect(page.locator('text="Credit or debit card"')).toBeVisible();
     
-    // Select "Credit or debit card"
-    await page.getByRole('button', { name: 'Credit or debit card' }).click();
-    await expect(page.locator('[aria-label="Credit or debit card"]')).toHaveAttribute('aria-expanded', 'true');
+    // Click "Credit or debit card"
+    await page.getByRole('radio', { name: 'Credit or debit card' }).click();
     
     // Find iframe and fill "Card number" field
     const cardNumberFrame = page.frameLocator('internal:attr=[title="Iframe for secured card number"i]');


### PR DESCRIPTION
Fix for v5.33.0 Web Dropin
- Use `radio` to select elements inside the iframe instead of `button`
- Remove the check to see whether 'aria-expanded' is 'true', it's an unnecessary check because: if the click didn't succeed, then we cannot fill the testcardnumber details anyway.