### PR TITLE
WaitForLoadState when loading iframes

### DIFF
--- a/tests/checkout/card.spec.js
+++ b/tests/checkout/card.spec.js
@@ -40,8 +40,5 @@ test('Card', async ({ page }) => {
     await expect(payButton).toBeVisible();
     await payButton.click();
     
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
-    
     await expect(page.locator('text="Return Home"')).toBeVisible();
 });

--- a/tests/checkout/card.spec.js
+++ b/tests/checkout/card.spec.js
@@ -13,6 +13,11 @@ test('Card', async ({ page }) => {
 
     // Click "Continue to checkout"
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
+
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle');
+    
+    // Assert that "Card number" is visible within iframe
     await expect(page.locator('text="Card number"')).toBeVisible();
     
     // Find iframe and fill "Card number" field
@@ -34,6 +39,9 @@ test('Card', async ({ page }) => {
     const payButton = page.locator('.adyen-checkout__button__text >> visible=true');
     await expect(payButton).toBeVisible();
     await payButton.click();
-
+    
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle');
+    
     await expect(page.locator('text="Return Home"')).toBeVisible();
 });

--- a/tests/checkout/dropin-card.spec.js
+++ b/tests/checkout/dropin-card.spec.js
@@ -54,8 +54,5 @@ test('Dropin Card', async ({ page }) => {
     await expect(payButton).toBeVisible();
     await payButton.click();
     
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
-    
     await expect(page.locator('text="Return Home"')).toBeVisible();
 });

--- a/tests/checkout/dropin-card.spec.js
+++ b/tests/checkout/dropin-card.spec.js
@@ -13,6 +13,11 @@ test('Dropin Card', async ({ page }) => {
 
     // Click "Continue to checkout"
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
+
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle');
+    
+    // Assert that "Credit or debit card" is visible
     await expect(page.locator('text="Credit or debit card"')).toBeVisible();
 
     // Click "Credit or debit card"
@@ -25,6 +30,9 @@ test('Dropin Card', async ({ page }) => {
         // Click radio button for > Adyen-Web 5.33.x or higher
         await radioButton.click();
     }
+
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle')
     
     // Find iframe and fill "Card number" field
     const cardNumberFrame = page.frameLocator('internal:attr=[title="Iframe for secured card number"i]');
@@ -45,6 +53,9 @@ test('Dropin Card', async ({ page }) => {
     const payButton = page.locator('.adyen-checkout__button__text >> visible=true');
     await expect(payButton).toBeVisible();
     await payButton.click();
-
+    
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle');
+    
     await expect(page.locator('text="Return Home"')).toBeVisible();
 });

--- a/tests/checkout/dropin-sepa.spec.js
+++ b/tests/checkout/dropin-sepa.spec.js
@@ -12,8 +12,12 @@ test('Dropin SEPA', async ({ page }) => {
     await expect(page.locator('text="Cart"')).toBeVisible();
 
     // Click "Continue to checkout"
-    
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
+    
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle');
+    
+    // Assert that "SEPA Direct Debit" is visible
     await expect(page.locator('text="SEPA Direct Debit"')).toBeVisible();
 
     // Select "SEPA"
@@ -25,6 +29,9 @@ test('Dropin SEPA', async ({ page }) => {
     const payButton = page.locator('.adyen-checkout__button.adyen-checkout__button--pay >> visible=true');
     await expect(payButton).toBeVisible();
     await payButton.click();
-
+    
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle');
+    
     await expect(page.locator('text="Return Home"')).toBeVisible();
 });

--- a/tests/checkout/dropin-sepa.spec.js
+++ b/tests/checkout/dropin-sepa.spec.js
@@ -30,8 +30,5 @@ test('Dropin SEPA', async ({ page }) => {
     await expect(payButton).toBeVisible();
     await payButton.click();
     
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
-    
     await expect(page.locator('text="Return Home"')).toBeVisible();
 });

--- a/tests/subscription/card.spec.js
+++ b/tests/subscription/card.spec.js
@@ -13,6 +13,11 @@ test('Card', async ({ page }) => {
 
     // Click "Continue to confirm subscription"
     await page.getByRole('link', { name: 'Continue to confirm subscription' }).click();
+    
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle');
+    
+    // Assert that "Card number" is visible within iframe.
     await expect(page.locator('text="Card number"')).toBeVisible();
     
     // Find iframe and fill "Card number" field
@@ -34,6 +39,9 @@ test('Card', async ({ page }) => {
     const confirmButton = page.locator('.adyen-checkout__button__text >> visible=true');
     await expect(confirmButton).toBeVisible();
     await confirmButton.click();
-
+    
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle');
+    
     await expect(page.locator('text="Return to Shopper View"')).toBeVisible();
 });

--- a/tests/subscription/card.spec.js
+++ b/tests/subscription/card.spec.js
@@ -40,8 +40,5 @@ test('Card', async ({ page }) => {
     await expect(confirmButton).toBeVisible();
     await confirmButton.click();
     
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
-    
     await expect(page.locator('text="Return to Shopper View"')).toBeVisible();
 });

--- a/tests/subscription/card.spec.js
+++ b/tests/subscription/card.spec.js
@@ -17,7 +17,7 @@ test('Card', async ({ page }) => {
     // Wait for network state to be idle
     await page.waitForLoadState('networkidle');
     
-    // Assert that "Card number" is visible within iframe.
+    // Assert that "Card number" is visible within iframe
     await expect(page.locator('text="Card number"')).toBeVisible();
     
     // Find iframe and fill "Card number" field

--- a/tests/subscription/dropin-card.spec.js
+++ b/tests/subscription/dropin-card.spec.js
@@ -54,8 +54,5 @@ test('Dropin Card', async ({ page }) => {
     await expect(confirmButton).toBeVisible();
     await confirmButton.click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
-    
     await expect(page.locator('text="Return to Shopper View"')).toBeVisible();
 });

--- a/tests/subscription/dropin-card.spec.js
+++ b/tests/subscription/dropin-card.spec.js
@@ -13,6 +13,11 @@ test('Dropin Card', async ({ page }) => {
 
     // Click "Continue to confirm subscription"
     await page.getByRole('link', { name: 'Continue to confirm subscription' }).click();
+
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle');
+    
+    // Assert that "Credit or debit card" is visible within iframe
     await expect(page.locator('text="Credit or debit card"')).toBeVisible();
 
     // Click "Credit or debit card"
@@ -25,6 +30,9 @@ test('Dropin Card', async ({ page }) => {
         // Click radio button for > Adyen-Web 5.33.x or higher
         await radioButton.click();
     }
+
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle')
     
     // Find iframe and fill "Card number" field
     const cardNumberFrame = page.frameLocator('internal:attr=[title="Iframe for secured card number"i]');
@@ -46,5 +54,8 @@ test('Dropin Card', async ({ page }) => {
     await expect(confirmButton).toBeVisible();
     await confirmButton.click();
 
+    // Wait for network state to be idle
+    await page.waitForLoadState('networkidle');
+    
     await expect(page.locator('text="Return to Shopper View"')).toBeVisible();
 });


### PR DESCRIPTION
When Click To Pay is enabled, a screen pops-up to check whether there's a stored sessionCookie or saved payment methods for the shopper. To account for this behavior, our E2E test need to be more robust to catch potential timeout.

By waiting for the 'networkidle' using playwright's waitForLoadState(...), we gracefully wait for it load before we do any operations such as clicking/assertions etc.