### PR TITLE
Frame locator partial string match

### DIFF
--- a/tests/checkout/card.spec.js
+++ b/tests/checkout/card.spec.js
@@ -21,15 +21,15 @@ test('Card', async ({ page }) => {
     await expect(page.locator('text="Card number"')).toBeVisible();
     
     // Find iframe and fill "Card number" field
-    const cardNumberFrame = page.frameLocator('internal:attr=[title="Iframe for secured card number"i]');
+    const cardNumberFrame = await page.frameLocator('iframe[title*="card number"]');
     await cardNumberFrame.getByPlaceholder('1234 5678 9012 3456').fill('4166 6766 6766 6746');
 
     // Find iframe and fill "Expiry date" field
-    const expiryDateFrame = page.frameLocator('internal:attr=[title="Iframe for secured card expiry date"i]');
+    const expiryDateFrame = await page.frameLocator('iframe[title*="expiry date"]');
     await expiryDateFrame.getByPlaceholder('MM/YY').fill('03/30');
 
     // Find iframe and fill "CVC / CVV" field
-    const cvcFrame = page.frameLocator('internal:attr=[title="Iframe for secured card security code"i]');
+    const cvcFrame = await page.frameLocator('iframe[title*="security code"]');
     await cvcFrame.getByPlaceholder('3 digits').fill('737');
    
     // Find and fill "Name on card" field - Note: this field is not contained within an iframe

--- a/tests/checkout/dropin-card.spec.js
+++ b/tests/checkout/dropin-card.spec.js
@@ -35,15 +35,15 @@ test('Dropin Card', async ({ page }) => {
     await page.waitForLoadState('networkidle')
     
     // Find iframe and fill "Card number" field
-    const cardNumberFrame = page.frameLocator('internal:attr=[title="Iframe for secured card number"i]');
+    const cardNumberFrame = await page.frameLocator('iframe[title*="card number"]');
     await cardNumberFrame.getByPlaceholder('1234 5678 9012 3456').fill('4166 6766 6766 6746');
 
     // Find iframe and fill "Expiry date" field
-    const expiryDateFrame = page.frameLocator('internal:attr=[title="Iframe for secured card expiry date"i]');
+    const expiryDateFrame = await page.frameLocator('iframe[title*="expiry date"]');
     await expiryDateFrame.getByPlaceholder('MM/YY').fill('03/30');
 
     // Find iframe and fill "CVC / CVV" field
-    const cvcFrame = page.frameLocator('internal:role=region[name="Credit or debit card"i] >> internal:attr=[title="Iframe for secured card security code"i]');
+    const cvcFrame = await page.frameLocator('iframe[title*="security code"]');
     await cvcFrame.getByPlaceholder('3 digits').fill('737');
    
     // Find and fill "Name on card" field - Note: this field is not contained within an iframe

--- a/tests/checkout/dropin-card.spec.js
+++ b/tests/checkout/dropin-card.spec.js
@@ -42,8 +42,9 @@ test('Dropin Card', async ({ page }) => {
     const expiryDateFrame = await page.frameLocator('iframe[title*="expiry date"]');
     await expiryDateFrame.getByPlaceholder('MM/YY').fill('03/30');
 
-    // Find iframe and fill "CVC / CVV" field
-    const cvcFrame = await page.frameLocator('iframe[title*="security code"]');
+    // Find iframe for CVC
+    const cvcFrame = await page.getByRole('region[name="Credit or debit card"i]').frameLocator('iframe[title*="security code"]');
+    // Fill "CVC / CVV" field
     await cvcFrame.getByPlaceholder('3 digits').fill('737');
    
     // Find and fill "Name on card" field - Note: this field is not contained within an iframe

--- a/tests/checkout/ideal.spec.js
+++ b/tests/checkout/ideal.spec.js
@@ -13,10 +13,10 @@ test('iDEAL', async ({ page }) => {
 
     // Click "Continue to checkout"
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
-    await expect(page.locator('text="Select your bank"')).toBeVisible();
+    await expect(page.getByTitle('Select your bank')).toBeVisible();
 
     // Click "Select your bank"
-    await page.click('text="Select your bank"');
+    await page.getByTitle('Select your bank').click();
 
     // Choose "Test Issuer"
     const element = page.locator('input[aria-autocomplete="list"]');

--- a/tests/giftcard/component-givex-giftcard-and-scheme.spec.js
+++ b/tests/giftcard/component-givex-giftcard-and-scheme.spec.js
@@ -69,8 +69,9 @@ async function enterSchemeDetails(page) {
     const expiryDateFrame = page.frameLocator('internal:attr=[title="Iframe for secured card expiry date"i]');
     await expiryDateFrame.getByPlaceholder('MM/YY').fill('03/30');
 
-    // Find iframe and fill "CVC / CVV" field
-    const cvcFrame = page.frameLocator('internal:attr=[title="Iframe for secured card security code"i]');
+    // Find iframe for CVC
+    const cvcFrame = await page.getByRole('region[name="Credit or debit card"i]').frameLocator('iframe[title*="security code"]');
+    // Fill "CVC / CVV" field
     await cvcFrame.getByPlaceholder('3 digits').fill('737');
    
     // Find and fill "Name on card" field - Note: this field is not contained within an iframe

--- a/tests/giftcard/component-givex-giftcard-and-scheme.spec.js
+++ b/tests/giftcard/component-givex-giftcard-and-scheme.spec.js
@@ -69,9 +69,8 @@ async function enterSchemeDetails(page) {
     const expiryDateFrame = page.frameLocator('internal:attr=[title="Iframe for secured card expiry date"i]');
     await expiryDateFrame.getByPlaceholder('MM/YY').fill('03/30');
 
-    // Find iframe for CVC
-    const cvcFrame = await page.getByRole('region[name="Credit or debit card"i]').frameLocator('iframe[title*="security code"]');
-    // Fill "CVC / CVV" field
+    // Find iframe and fill "CVC / CVV" field
+    const cvcFrame = page.frameLocator('internal:attr=[title="Iframe for secured card security code"i]');
     await cvcFrame.getByPlaceholder('3 digits').fill('737');
    
     // Find and fill "Name on card" field - Note: this field is not contained within an iframe

--- a/tests/subscription/card.spec.js
+++ b/tests/subscription/card.spec.js
@@ -19,17 +19,17 @@ test('Card', async ({ page }) => {
     
     // Assert that "Card number" is visible within iframe
     await expect(page.locator('text="Card number"')).toBeVisible();
-    
+
     // Find iframe and fill "Card number" field
-    const cardNumberFrame = page.frameLocator('internal:attr=[title="Iframe for secured card number"i]');
+    const cardNumberFrame = await page.frameLocator('iframe[title*="card number"]');
     await cardNumberFrame.getByPlaceholder('1234 5678 9012 3456').fill('4166 6766 6766 6746');
 
     // Find iframe and fill "Expiry date" field
-    const expiryDateFrame = page.frameLocator('internal:attr=[title="Iframe for secured card expiry date"i]');
+    const expiryDateFrame = await page.frameLocator('iframe[title*="expiry date"]');
     await expiryDateFrame.getByPlaceholder('MM/YY').fill('03/30');
 
     // Find iframe and fill "CVC / CVV" field
-    const cvcFrame = page.frameLocator('internal:attr=[title="Iframe for secured card security code"i]');
+    const cvcFrame = await page.frameLocator('iframe[title*="security code"]');
     await cvcFrame.getByPlaceholder('3 digits').fill('737');
    
     // Find and fill "Name on card" field - Note: this field is not contained within an iframe

--- a/tests/subscription/dropin-card.spec.js
+++ b/tests/subscription/dropin-card.spec.js
@@ -35,15 +35,15 @@ test('Dropin Card', async ({ page }) => {
     await page.waitForLoadState('networkidle')
     
     // Find iframe and fill "Card number" field
-    const cardNumberFrame = page.frameLocator('internal:attr=[title="Iframe for secured card number"i]');
+    const cardNumberFrame = await page.frameLocator('iframe[title*="card number"]');
     await cardNumberFrame.getByPlaceholder('1234 5678 9012 3456').fill('4166 6766 6766 6746');
 
     // Find iframe and fill "Expiry date" field
-    const expiryDateFrame = page.frameLocator('internal:attr=[title="Iframe for secured card expiry date"i]');
+    const expiryDateFrame = await page.frameLocator('iframe[title*="expiry date"]');
     await expiryDateFrame.getByPlaceholder('MM/YY').fill('03/30');
 
     // Find iframe and fill "CVC / CVV" field
-    const cvcFrame = page.frameLocator('internal:role=region[name="Credit or debit card"i] >> internal:attr=[title="Iframe for secured card security code"i]');
+    const cvcFrame = await page.frameLocator('iframe[title*="security code"]');
     await cvcFrame.getByPlaceholder('3 digits').fill('737');
    
     // Find and fill "Name on card" field - Note: this field is not contained within an iframe

--- a/tests/subscription/dropin-card.spec.js
+++ b/tests/subscription/dropin-card.spec.js
@@ -42,8 +42,9 @@ test('Dropin Card', async ({ page }) => {
     const expiryDateFrame = await page.frameLocator('iframe[title*="expiry date"]');
     await expiryDateFrame.getByPlaceholder('MM/YY').fill('03/30');
 
-    // Find iframe and fill "CVC / CVV" field
-    const cvcFrame = await page.frameLocator('iframe[title*="security code"]');
+    // Find iframe for CVC
+    const cvcFrame = await page.getByRole('region[name="Credit or debit card"i]').frameLocator('iframe[title*="security code"]');
+    // Fill "CVC / CVV" field
     await cvcFrame.getByPlaceholder('3 digits').fill('737');
    
     // Find and fill "Name on card" field - Note: this field is not contained within an iframe


### PR DESCRIPTION
PR to update the way we locate the iFrame. 
The latest DropIn has changed the iFrame title so it is now necessary to use a partial matching (instead of a full string match) to work with different versions of Drop-in.