### PR TITLE
Extend expect timeout

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -19,7 +19,7 @@ const config = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000
+    timeout: 10000
   },
 
   /* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
Occasionally the Klarna Pay Now test fails: the Klarna sandbox takes some time to load/render and the test fails (cannot find page title).
This PR extends the timeout to 10sec