### PR TITLE
Remove legacy code (Drop-in v5.32.0)

### DIFF
--- a/tests/checkout/dropin-card.spec.js
+++ b/tests/checkout/dropin-card.spec.js
@@ -22,14 +22,7 @@ test('Dropin Card', async ({ page }) => {
 
     // Click "Credit or debit card"
     const radioButton = await page.getByRole('radio', { name: 'Credit or debit card' });
-    if (await radioButton.count() === 0) {
-        // Click normal button for < Adyen-Web 5.32.x or lower
-        await page.getByRole('button', { name: 'Credit or debit card' }).click();
-    }
-    else {
-        // Click radio button for > Adyen-Web 5.33.x or higher
-        await radioButton.click();
-    }
+    await radioButton.click();
 
     // Wait for network state to be idle
     await page.waitForLoadState('networkidle')


### PR DESCRIPTION
All sample apps use Web Drop-in v5.40.0+. This PR removes the legacy code which was necessary to support E2E testing in Drop-in v5.32.0