### PR TITLE
Giving webhook tests

### DIFF
--- a/tests/giving/card-and-donation-cancel.spec.js
+++ b/tests/giving/card-and-donation-cancel.spec.js
@@ -5,7 +5,7 @@ const utilities = require('../utilities');
 test('Card and Cancel', async ({ page }) => {
     await page.goto('/');
 
-    await expect(page).toHaveTitle(/Adyen Giving Demo - Select type/);
+    await expect(page).toHaveTitle(/Adyen Giving Demo/);
 
     // Select "Card"
     await page.getByRole('link', { name: 'Card', exact: true }).click();

--- a/tests/giving/card-and-donation.spec.js
+++ b/tests/giving/card-and-donation.spec.js
@@ -5,7 +5,7 @@ const utilities = require('../utilities');
 test('Card and donate', async ({ page }) => {
     await page.goto('/');
 
-    await expect(page).toHaveTitle(/Adyen Giving Demo - Select type/);
+    await expect(page).toHaveTitle(/Adyen Giving Demo/);
 
     // Select "Card"
     await page.getByRole('link', { name: 'Card', exact: true }).click();

--- a/tests/giving/webhook-failure.spec.js
+++ b/tests/giving/webhook-failure.spec.js
@@ -1,0 +1,42 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+// test webhook is rejected (invalid HMAC signature)
+test('Webhook Notification', async ({ request }) => {
+    const notifications = await request.post(`/api/webhooks/notifications`, {
+        data: {
+            "live": "false",
+            "notificationItems":[
+                {
+                    "NotificationRequestItem":{
+                        "additionalData":{
+                            "hmacSignature":"INVALID_HMAC_SIGNATURE"
+                        },
+                        "eventCode":"AUTHORISATION",
+                        "success":"true",
+                        "eventDate":"2019-06-28T18:03:50+01:00",
+                        "merchantAccountCode":"YOUR_MERCHANT_ACCOUNT",
+                        "pspReference": "7914073381342284",
+                        "merchantReference": "YOUR_REFERENCE",
+                        "amount": {
+                            "value":24999,
+                            "currency":"EUR"
+                        }
+                    }
+                }
+            ]
+        }
+    });
+
+    /// Verify notification is not accepted (invalid HMAC)
+
+    // Status code not 404 (verify webhook is found)
+    expect(notifications.status()).not.toEqual(404);
+
+    // Status code not 200 (verify webhook does not accept the notification ie HMAC invalid)
+    expect(notifications.status()).not.toEqual(200);
+
+    // Body response does not contain [accepted]
+    notifications.text()
+        .then(value => {expect(value).not.toEqual("[accepted]");} );
+});

--- a/tests/giving/webhook.spec.js
+++ b/tests/giving/webhook.spec.js
@@ -1,0 +1,45 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const utilities = require('../utilities');
+
+// test webhook is successfully delivered
+test('Webhook Notification', async ({ request }) => {
+
+    var notificationRequestItem = {
+        "eventCode":"AUTHORISATION",
+        "success":"true",
+        "eventDate":"2019-06-28T18:03:50+01:00",
+        "merchantAccountCode":"YOUR_MERCHANT_ACCOUNT",
+        "pspReference": "7914073381342284",
+        "merchantReference": "YOUR_REFERENCE",
+        "amount": {
+            "value":1130,
+            "currency":"EUR"
+        }
+    };
+
+    // calculate signature from payload
+    const hmacSignature = await utilities.calculateHmacSignature(notificationRequestItem);
+    // add hmacSignature to 'additionalData'
+    notificationRequestItem["additionalData"] = {"hmacSignature" : ""+hmacSignature+""}
+
+    // POST webhook
+    const notifications = await request.post(`/api/webhooks/notifications`, {
+        data: {
+            "live": "false",
+            "notificationItems":[
+                {
+                    "NotificationRequestItem": notificationRequestItem    
+                }           
+            ]
+        }
+    });
+
+    // Verify status code 
+    expect(notifications.status()).toEqual(200);
+
+    // Verify body response 
+    notifications.text()
+        .then(value => {expect(value).toEqual("[accepted]");} );
+});
+


### PR DESCRIPTION
Update test suite to support Giving example:

- update expected title (*)
- add webhook tests

(*) the Giving example in Java will need to be corrected to work with the new version of the tests