### PR TITLE
Set different timeout local vs CI

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -17,8 +17,10 @@ const config = {
     /**
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
+     * 
+     * note: waiting longer on CI
      */
-    timeout: 40 * 1000
+    timeout: process.env.CI ? 40 * 1000 : 5 * 1000
   },
 
   /* Run tests in files in parallel */


### PR DESCRIPTION
PR to customise different timeouts:

- on CI wait up to 40 sec (necessary as the build runs slower)
- on localhost wait up to 5 sec (fail faster on localhost instead of waiting 40 sec when an element cannot be found)