### PR TITLE
AfP tests: use utilities.js

### DIFF
--- a/tests/afp/dashboard.spec.js
+++ b/tests/afp/dashboard.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
-const utils = require('./utils');
+const utilities = require('../utilities');
 
 test('Dashboard', async ({ page }) => {
   await page.goto('/');
@@ -9,7 +9,7 @@ test('Dashboard', async ({ page }) => {
   await page.goto('/login');
   await expect(page.locator('text="Login"')).toBeVisible();
   // perform login
-  await page.fill('input[name="username"]', utils.USERNAME);
+  await page.fill('input[name="username"]', utilities.USERNAME);
   await page.fill('input[name="password"]', "123");
   await page.getByRole('button', { name: 'Submit' }).click();
 

--- a/tests/afp/utils.js
+++ b/tests/afp/utils.js
@@ -1,8 +1,0 @@
-const dotenv = require('dotenv');
-
-dotenv.config();
-
-module.exports = {
-    // valid AccountHolder id
-    USERNAME: process.env.AFP_USERNAME,
-};

--- a/tests/utilities.js
+++ b/tests/utilities.js
@@ -16,6 +16,9 @@ module.exports = {
     /** Cardholder name. */
     NAME_ON_CARD: 'J. Smith',
 
+    /** valid AccountHolder id for AfP tests: use env variable to not expose valid Id */
+    USERNAME: process.env.AFP_USERNAME || "na",
+
     /** Utility function to fill card details on the Adyen.Web.Component - Sets default values automatically if you do not overwrite it manually.
      * See: https://docs.adyen.com/online-payments/build-your-integration/?platform=Web&integration=Components.
      * Example usage:


### PR DESCRIPTION
Refactor AfP tests to use `utilities` (shared across all tests) and delete local `utils` file