### PR TITLE
Webhook tests: support either 202 and 200 response status code 

### DIFF
--- a/tests/advanced-checkout/webhook.spec.js
+++ b/tests/advanced-checkout/webhook.spec.js
@@ -35,11 +35,22 @@ test('Webhook Notification', async ({ request }) => {
         }
     });
 
-    // Verify status code 
-    expect(notifications.status()).toEqual(200);
+    var notifications_status = notifications.status();
 
-    // Verify body response 
-    notifications.text()
-        .then(value => {expect(value).toEqual("[accepted]");} );
+    if (notifications_status === 202) {
+        // Verify status code 202
+        expect(notifications.status()).toEqual(202);
+
+        // Verify empty response body
+        notifications.text()
+            .then(value => { expect(value).toEqual(""); });
+    } else {
+        // Verify legacy webhook acknowledgment (status code 200)
+        expect(notifications.status()).toEqual(200);
+
+        // Verify legacy webhook acknowledgment (response body `[accepted]`)
+        notifications.text()
+            .then(value => { expect(value).toEqual("[accepted]"); });
+    }
 });
 

--- a/tests/authorisation-adjustment/webhook.spec.js
+++ b/tests/authorisation-adjustment/webhook.spec.js
@@ -35,11 +35,22 @@ test('Webhook Notification', async ({ request }) => {
         }
     });
 
-    // Verify status code 
-    expect(notifications.status()).toEqual(200);
+    var notifications_status = notifications.status();
+    
+    if (notifications_status === 202) {
+        // Verify status code 202
+        expect(notifications.status()).toEqual(202);
 
-    // Verify body response 
-    notifications.text()
-        .then(value => {expect(value).toEqual("[accepted]");} );
+        // Verify empty response body
+        notifications.text()
+            .then(value => { expect(value).toEqual(""); });
+    } else {
+        // Verify legacy webhook acknowledgment (status code 200)
+        expect(notifications.status()).toEqual(200);
+
+        // Verify legacy webhook acknowledgment (response body `[accepted]`)
+        notifications.text()
+            .then(value => { expect(value).toEqual("[accepted]"); });
+    }
 });
 

--- a/tests/checkout/webhook.spec.js
+++ b/tests/checkout/webhook.spec.js
@@ -34,12 +34,23 @@ test('Webhook Notification', async ({ request }) => {
             ]
         }
     });
+ 
+    var notifications_status = notifications.status();
+    
+    if (notifications_status === 202) {
+        // Verify status code 202
+        expect(notifications.status()).toEqual(202);
 
-    // Verify status code 
-    expect(notifications.status()).toEqual(200);
+        // Verify empty response body
+        notifications.text()
+            .then(value => { expect(value).toEqual(""); });
+    } else {
+        // Verify legacy webhook acknowledgment (status code 200)
+        expect(notifications.status()).toEqual(200);
 
-    // Verify body response 
-    notifications.text()
-        .then(value => {expect(value).toEqual("[accepted]");} );
+        // Verify legacy webhook acknowledgment (response body `[accepted]`)
+        notifications.text()
+            .then(value => { expect(value).toEqual("[accepted]"); });
+    }
 });
 

--- a/tests/giftcard/webhook.spec.js
+++ b/tests/giftcard/webhook.spec.js
@@ -47,11 +47,22 @@ test('Webhook Notification', async ({ request }) => {
         }
     });
 
-    // Verify status code 
-    expect(notifications.status()).toEqual(200);
+    var notifications_status = notifications.status();
+    
+    if (notifications_status === 202) {
+        // Verify status code 202
+        expect(notifications.status()).toEqual(202);
 
-    // Verify body response 
-    notifications.text()
-        .then(value => { expect(value).toEqual("[accepted]"); });
+        // Verify empty response body
+        notifications.text()
+            .then(value => { expect(value).toEqual(""); });
+    } else {
+        // Verify legacy webhook acknowledgment (status code 200)
+        expect(notifications.status()).toEqual(200);
+
+        // Verify legacy webhook acknowledgment (response body `[accepted]`)
+        notifications.text()
+            .then(value => { expect(value).toEqual("[accepted]"); });
+    }
 });
 

--- a/tests/giving/webhook.spec.js
+++ b/tests/giving/webhook.spec.js
@@ -35,11 +35,22 @@ test('Webhook Notification', async ({ request }) => {
         }
     });
 
-    // Verify status code 
-    expect(notifications.status()).toEqual(200);
+    var notifications_status = notifications.status();
+    
+    if (notifications_status === 202) {
+        // Verify status code 202
+        expect(notifications.status()).toEqual(202);
 
-    // Verify body response 
-    notifications.text()
-        .then(value => {expect(value).toEqual("[accepted]");} );
+        // Verify empty response body
+        notifications.text()
+            .then(value => { expect(value).toEqual(""); });
+    } else {
+        // Verify legacy webhook acknowledgment (status code 200)
+        expect(notifications.status()).toEqual(200);
+
+        // Verify legacy webhook acknowledgment (response body `[accepted]`)
+        notifications.text()
+            .then(value => { expect(value).toEqual("[accepted]"); });
+    }
 });
 

--- a/tests/in-person-payments/webhook.spec.js
+++ b/tests/in-person-payments/webhook.spec.js
@@ -35,11 +35,22 @@ test('Webhook Notification', async ({ request }) => {
         }
     });
 
-    // Verify status code 
-    expect(notifications.status()).toEqual(200);
+    var notifications_status = notifications.status();
+    
+    if (notifications_status === 202) {
+        // Verify status code 202
+        expect(notifications.status()).toEqual(202);
 
-    // Verify body response 
-    notifications.text()
-        .then(value => {expect(value).toEqual("[accepted]");} );
+        // Verify empty response body
+        notifications.text()
+            .then(value => { expect(value).toEqual(""); });
+    } else {
+        // Verify legacy webhook acknowledgment (status code 200)
+        expect(notifications.status()).toEqual(200);
+
+        // Verify legacy webhook acknowledgment (response body `[accepted]`)
+        notifications.text()
+            .then(value => { expect(value).toEqual("[accepted]"); });
+    }
 });
 

--- a/tests/paybylink/webhook.spec.js
+++ b/tests/paybylink/webhook.spec.js
@@ -37,11 +37,22 @@ test('Webhook Notification', async ({ request }) => {
         }
     });
 
-    // Verify status code 
-    expect(notifications.status()).toEqual(200);
+    var notifications_status = notifications.status();
+    
+    if (notifications_status === 202) {
+        // Verify status code 202
+        expect(notifications.status()).toEqual(202);
 
-    // Verify body response 
-    notifications.text()
-        .then(value => {expect(value).toEqual("[accepted]");} );
+        // Verify empty response body
+        notifications.text()
+            .then(value => { expect(value).toEqual(""); });
+    } else {
+        // Verify legacy webhook acknowledgment (status code 200)
+        expect(notifications.status()).toEqual(200);
+
+        // Verify legacy webhook acknowledgment (response body `[accepted]`)
+        notifications.text()
+            .then(value => { expect(value).toEqual("[accepted]"); });
+    }
 });
 

--- a/tests/subscription/webhook.spec.js
+++ b/tests/subscription/webhook.spec.js
@@ -39,11 +39,22 @@ test('Webhook Notification', async ({ request }) => {
         }
     });
 
-    // Verify status code 
-    expect(notifications.status()).toEqual(200);
+    var notifications_status = notifications.status();
+    
+    if (notifications_status === 202) {
+        // Verify status code 202
+        expect(notifications.status()).toEqual(202);
 
-    // Verify body response 
-    notifications.text()
-        .then(value => { expect(value).toEqual("[accepted]"); });
+        // Verify empty response body
+        notifications.text()
+            .then(value => { expect(value).toEqual(""); });
+    } else {
+        // Verify legacy webhook acknowledgment (status code 200)
+        expect(notifications.status()).toEqual(200);
+
+        // Verify legacy webhook acknowledgment (response body `[accepted]`)
+        notifications.text()
+            .then(value => { expect(value).toEqual("[accepted]"); });
+    }
 });
 


### PR DESCRIPTION
The latest approach to accepting webhooks requires sending the response code `202` and an empty response body.

This PR updates the E2E tests to support  2 approaches (either `202` with an empty response body or legacy `200` with a response body `[accepted]`). This is needed as we want to incrementally update all sample apps.
