### PR TITLE
Increate test timeout

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -42,7 +42,7 @@ const config = {
     baseURL: process.env.URL || 'http://localhost:8080',
 
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-    actionTimeout: 40 * 1000,
+    actionTimeout: 120 * 1000,
 
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://localhost:3000',


### PR DESCRIPTION
Few tests occasionally fail as they reach max timeout (40 sec). Locally every test is very fast, the cause is likely the available (shared) resources of the GitHub actions.

This PR extents the max test timeout to 2 min.