### PR TITLE
Refactor to wait for load event

### DIFF
--- a/tests/advanced-checkout/card.spec.js
+++ b/tests/advanced-checkout/card.spec.js
@@ -15,8 +15,8 @@ test('Card', async ({ page }) => {
     // Click "Continue to checkout"
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
     
     // Assert that "Card number" is visible within iframe
     await expect(page.locator('text="Card number"')).toBeVisible();

--- a/tests/advanced-checkout/dropin-card.spec.js
+++ b/tests/advanced-checkout/dropin-card.spec.js
@@ -15,8 +15,8 @@ test('Dropin Card', async ({ page }) => {
     // Click "Continue to checkout"
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
     
     // Assert that "Credit or debit card" is visible
     await expect(page.locator('text="Credit or debit card"')).toBeVisible();
@@ -25,8 +25,8 @@ test('Dropin Card', async ({ page }) => {
     const radioButton = await page.getByRole('radio', { name: 'Credit or debit card' });
     await radioButton.click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle')
+    // Wait for load event
+    await page.waitForLoadState('load');
 
     // Fill card details
     await utilities.fillDropinCardDetails(page);

--- a/tests/authorisation-adjustment/card-authorised.spec.js
+++ b/tests/authorisation-adjustment/card-authorised.spec.js
@@ -13,8 +13,8 @@ test('Card Authorised', async ({ page }) => {
     // Click "Continue to confirm booking"
     await page.getByRole('link', { name: 'Continue to confirm booking' }).click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
     
     // Assert that "Card number" is visible within iframe
     await expect(page.locator('text="Card number"')).toBeVisible();

--- a/tests/authorisation-adjustment/card-refused.spec.js
+++ b/tests/authorisation-adjustment/card-refused.spec.js
@@ -13,8 +13,8 @@ test('Card Refused', async ({ page }) => {
     // Click "Continue to confirm booking"
     await page.getByRole('link', { name: 'Continue to confirm booking' }).click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
     
     // Assert that "Card number" is visible within iframe
     await expect(page.locator('text="Card number"')).toBeVisible();

--- a/tests/checkout/card.spec.js
+++ b/tests/checkout/card.spec.js
@@ -15,8 +15,8 @@ test('Card', async ({ page }) => {
     // Click "Continue to checkout"
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
     
     // Assert that "Card number" is visible within iframe
     await expect(page.locator('text="Card number"')).toBeVisible();

--- a/tests/checkout/dropin-card.spec.js
+++ b/tests/checkout/dropin-card.spec.js
@@ -15,8 +15,8 @@ test('Dropin Card', async ({ page }) => {
     // Click "Continue to checkout"
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
     
     // Assert that "Credit or debit card" is visible
     await expect(page.locator('text="Credit or debit card"')).toBeVisible();
@@ -25,8 +25,8 @@ test('Dropin Card', async ({ page }) => {
     const radioButton = await page.getByRole('radio', { name: 'Credit or debit card' });
     await radioButton.click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle')
+    // Wait for load event
+    await page.waitForLoadState('load');
 
     // Fill card details
     await utilities.fillDropinCardDetails(page);

--- a/tests/checkout/dropin-sepa.spec.js
+++ b/tests/checkout/dropin-sepa.spec.js
@@ -14,8 +14,8 @@ test('Dropin SEPA', async ({ page }) => {
     // Click "Continue to checkout"
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
     
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
     
     // Assert that "SEPA Direct Debit" is visible
     await expect(page.locator('text="SEPA Direct Debit"')).toBeVisible();

--- a/tests/giving/card-and-donation-cancel.spec.js
+++ b/tests/giving/card-and-donation-cancel.spec.js
@@ -14,8 +14,8 @@ test('Card and Cancel', async ({ page }) => {
     // Click "Continue to checkout"
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
 
     // Assert that "Card number" is visible within iframe
     await expect(page.locator('text="Card number"')).toBeVisible();

--- a/tests/giving/card-and-donation.spec.js
+++ b/tests/giving/card-and-donation.spec.js
@@ -14,8 +14,8 @@ test('Card and donate', async ({ page }) => {
     // Click "Continue to checkout"
     await page.getByRole('link', { name: 'Continue to checkout' }).click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
     
     // Assert that "Card number" is visible within iframe
     await expect(page.locator('text="Card number"')).toBeVisible();

--- a/tests/paybylink/paybylink.spec.js
+++ b/tests/paybylink/paybylink.spec.js
@@ -18,8 +18,8 @@ test('Pay By Link', async ({ page }) => {
     // Create payment link
     await page.getByRole('button', { name: 'Create!' }).click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
 
     // Ensure the link with `uniqueReference` is created
     await expect(page.getByText(uniqueReference).first()).toBeVisible();
@@ -27,8 +27,8 @@ test('Pay By Link', async ({ page }) => {
     const link = await page.locator('text=/PL/').first();
     await link.click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
 
     // Check Pay by link text
     await page.getByText(/Pay by link/);

--- a/tests/subscription/card.spec.js
+++ b/tests/subscription/card.spec.js
@@ -15,8 +15,8 @@ test('Card', async ({ page }) => {
     // Click "Continue to confirm subscription"
     await page.getByRole('link', { name: 'Continue to confirm subscription' }).click();
     
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
 
     // Assert that "Card number" is visible within iframe
     await expect(page.locator('text="Card number"')).toBeVisible();

--- a/tests/subscription/dropin-card.spec.js
+++ b/tests/subscription/dropin-card.spec.js
@@ -15,8 +15,8 @@ test('Dropin Card', async ({ page }) => {
     // Click "Continue to confirm subscription"
     await page.getByRole('link', { name: 'Continue to confirm subscription' }).click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle');
+    // Wait for load event
+    await page.waitForLoadState('load');
     
     // Assert that "Credit or debit card" is visible within iframe
     await expect(page.locator('text="Credit or debit card"')).toBeVisible();
@@ -25,8 +25,8 @@ test('Dropin Card', async ({ page }) => {
     const radioButton = await page.getByRole('radio', { name: 'Credit or debit card' });
     await radioButton.click();
 
-    // Wait for network state to be idle
-    await page.waitForLoadState('networkidle')
+    // Wait for load event
+    await page.waitForLoadState('load');
     
     // Fill card details
     await utilities.fillDropinCardDetails(page);


### PR DESCRIPTION
Following Playwright [recommendations](https://playwright.dev/docs/api/class-page#page-wait-for-load-state) the test suite has been updated to use 
```
    // Wait for load event
    await page.waitForLoadState('load');
```
instead of
```
    // Wait for network state to be idle
    await page.waitForLoadState('networkidle');
```

This change is necessary to run the E2E testing suite against the [Vue Sample application](https://github.com/adyen-examples/adyen-vue-online-payments).

**Note**: the GiftCard test cases only work using `networkidle`, so they haven't been updated.
The reason might be the fact that the UI elements are created dynamically (hence the `load` event is already fired). I will create a new issue to investigate and address.