### PR TITLE
Giving tests: add page.waitForLoadState

### DIFF
--- a/tests/giving/card-and-donation-cancel.spec.js
+++ b/tests/giving/card-and-donation-cancel.spec.js
@@ -23,11 +23,14 @@ test('Card and Cancel', async ({ page }) => {
     // Fill card details
     await utilities.fillComponentCardDetails(page, { cardNumber: '5555 3412 4444 1115'});
 
-    // Click "Pay" button
+    // Click "Pay" button and go to Giving component
     const payButton = page.locator('.adyen-checkout__button__text >> visible=true');
     await expect(payButton).toBeVisible();
     await payButton.click();
 
+    // Wait for load event
+    await page.waitForLoadState('load');
+    
     // Click "Not now" button
     await page.getByText('Not now').click();
 

--- a/tests/giving/card-and-donation.spec.js
+++ b/tests/giving/card-and-donation.spec.js
@@ -23,11 +23,14 @@ test('Card and donate', async ({ page }) => {
     // Fill card details
     await utilities.fillComponentCardDetails(page, { cardNumber: '5555 3412 4444 1115'});
 
-    // Click "Pay" button
+    // Click "Pay" button and go to Giving component
     const payButton = page.locator('.adyen-checkout__button__text >> visible=true');
     await expect(payButton).toBeVisible();
     await payButton.click();
 
+    // Wait for load event
+    await page.waitForLoadState('load');
+    
     // Click "3.00" amount button
     await page.getByText('3.00').click();
     


### PR DESCRIPTION
Add `page.waitForLoadState` for the Giving component to load, to prevent  random failure during the execution of the GitHub action.